### PR TITLE
Complete Spot ROS 2 control hardware interface configuration

### DIFF
--- a/spot_description/urdf/spot.ros2_control.xacro
+++ b/spot_description/urdf/spot.ros2_control.xacro
@@ -61,7 +61,7 @@
 
     </xacro:macro>
 
-    <xacro:macro name="spot_ros2_control" params="interface_type has_arm hostname username password tf_prefix k_q_p k_qd_p">
+    <xacro:macro name="spot_ros2_control" params="interface_type has_arm hostname port certificate username password tf_prefix k_q_p k_qd_p">
         <!-- Currently implements a simple system interface that covers all joints of the robot.
         In the future, we could make different hardware interfaces for the body, arm, etc. -->
         <ros2_control name="SpotSystem" type="system">
@@ -74,6 +74,8 @@
             <xacro:if value="${interface_type == 'robot'}">
                 <plugin>spot_hardware_interface/SpotHardware</plugin>
                 <param name="hostname">$(optenv SPOT_IP ${hostname})</param>
+                <param name="port">$(optenv SPOT_PORT ${port})</param>
+                <param name="certificate">$(optenv SPOT_CERTIFICATE ${certificate})</param>
                 <param name="username">$(optenv BOSDYN_CLIENT_USERNAME ${username})</param>
                 <param name="password">$(optenv BOSDYN_CLIENT_PASSWORD ${password})</param>
                 <param name="k_q_p">${k_q_p}</param>

--- a/spot_description/urdf/spot.urdf.xacro
+++ b/spot_description/urdf/spot.urdf.xacro
@@ -24,6 +24,8 @@
   <xacro:arg name="add_ros2_control_tag" default="false" />
   <xacro:arg name="hardware_interface_type" default="mock" />
   <xacro:arg name="hostname" default="10.0.0.3" />
+  <xacro:arg name="port" default="0" />
+  <xacro:arg name="certificate" default="" />
   <xacro:arg name="username" default="username" />
   <xacro:arg name="password" default="password" />
   <xacro:arg name="k_q_p" default="" />
@@ -41,7 +43,9 @@
       <xacro:spot_ros2_control interface_type="$(arg hardware_interface_type)" 
                                has_arm="$(arg arm)" 
                                hostname="$(arg hostname)" 
-                               username="$(arg username)" 
+                               port="$(arg port)"
+                               certificate="$(arg certificate)"
+                               username="$(arg username)"
                                password="$(arg password)" 
                                tf_prefix="$(arg tf_prefix)" 
                                k_q_p="$(arg k_q_p)" 


### PR DESCRIPTION
This patch allows both user-defined port and SSL certificate to be configured for the Spot system hardware interface.