### PR TITLE
[SW-1999] Configure leasing mode for Spot ROS 2 control hardware interface

### DIFF
--- a/spot_description/urdf/spot.ros2_control.xacro
+++ b/spot_description/urdf/spot.ros2_control.xacro
@@ -61,7 +61,7 @@
 
     </xacro:macro>
 
-    <xacro:macro name="spot_ros2_control" params="interface_type has_arm hostname port certificate username password tf_prefix k_q_p k_qd_p">
+    <xacro:macro name="spot_ros2_control" params="interface_type has_arm leasing hostname port certificate username password tf_prefix k_q_p k_qd_p">
         <!-- Currently implements a simple system interface that covers all joints of the robot.
         In the future, we could make different hardware interfaces for the body, arm, etc. -->
         <ros2_control name="SpotSystem" type="system">
@@ -78,6 +78,7 @@
                 <param name="certificate">$(optenv SPOT_CERTIFICATE ${certificate})</param>
                 <param name="username">$(optenv BOSDYN_CLIENT_USERNAME ${username})</param>
                 <param name="password">$(optenv BOSDYN_CLIENT_PASSWORD ${password})</param>
+                <param name="leasing">${leasing}</param>
                 <param name="k_q_p">${k_q_p}</param>
                 <param name="k_qd_p">${k_qd_p}</param>
             </xacro:if>

--- a/spot_description/urdf/spot.urdf.xacro
+++ b/spot_description/urdf/spot.urdf.xacro
@@ -28,6 +28,7 @@
   <xacro:arg name="certificate" default="" />
   <xacro:arg name="username" default="username" />
   <xacro:arg name="password" default="password" />
+  <xacro:arg name="leasing" default="direct" />
   <xacro:arg name="k_q_p" default="" />
   <xacro:arg name="k_qd_p" default="" />
 
@@ -41,14 +42,15 @@
   <!-- Adding the ROS 2 control tags -->
   <xacro:if value="$(arg add_ros2_control_tag)">
       <xacro:spot_ros2_control interface_type="$(arg hardware_interface_type)" 
-                               has_arm="$(arg arm)" 
-                               hostname="$(arg hostname)" 
+                               has_arm="$(arg arm)"
+                               leasing="$(arg leasing)"
+                               hostname="$(arg hostname)"
                                port="$(arg port)"
                                certificate="$(arg certificate)"
                                username="$(arg username)"
-                               password="$(arg password)" 
-                               tf_prefix="$(arg tf_prefix)" 
-                               k_q_p="$(arg k_q_p)" 
+                               password="$(arg password)"
+                               tf_prefix="$(arg tf_prefix)"
+                               k_q_p="$(arg k_q_p)"
                                k_qd_p="$(arg k_qd_p)" />
   </xacro:if>
 


### PR DESCRIPTION
This patch goes hand in hand with https://github.com/bdaiinstitute/spot_ros2/pull/586, allowing leasing mode configuration on the `spot_hardware_interface` description.