### PR TITLE
[SW-2052] add imu sensor to ros2 control urdf

### DIFF
--- a/spot_description/urdf/spot.ros2_control.xacro
+++ b/spot_description/urdf/spot.ros2_control.xacro
@@ -89,7 +89,7 @@
             <xacro:if value="${has_arm}">
                 <xacro:arm tf_prefix="${tf_prefix}" />
             </xacro:if>
-            <sensor name="imu_sensor" tf_prefix="${tf_prefix}">
+            <sensor name="{tf_prefix}imu_sensor" tf_prefix="${tf_prefix}">
                 <state_interface name="orientation.x"/>
                 <state_interface name="orientation.y"/>
                 <state_interface name="orientation.z"/>

--- a/spot_description/urdf/spot.ros2_control.xacro
+++ b/spot_description/urdf/spot.ros2_control.xacro
@@ -89,6 +89,19 @@
             <xacro:if value="${has_arm}">
                 <xacro:arm tf_prefix="${tf_prefix}" />
             </xacro:if>
+            <sensor name="imu_sensor" tf_prefix="${tf_prefix}">
+                <state_interface name="orientation.x"/>
+                <state_interface name="orientation.y"/>
+                <state_interface name="orientation.z"/>
+                <state_interface name="orientation.w"/>
+                <state_interface name="angular_velocity.x"/>
+                <state_interface name="angular_velocity.y"/>
+                <state_interface name="angular_velocity.z"/>
+                <state_interface name="linear_acceleration.x"/>
+                <state_interface name="linear_acceleration.y"/>
+                <state_interface name="linear_acceleration.z"/>
+                <param name="frame_id">imu_link</param>
+            </sensor>
         </ros2_control>
     </xacro:macro>
 


### PR DESCRIPTION
Adds IMU sensor info as a state interface in `spot.ros2_control.xacro`