### PR TITLE
Fixed rvizconfig launch argument

### DIFF
--- a/spot_description/launch/description.launch.py
+++ b/spot_description/launch/description.launch.py
@@ -91,7 +91,7 @@ def generate_launch_description() -> launch.LaunchDescription:
                 executable="rviz2",
                 name="rviz2",
                 output="screen",
-                arguments=["-d" + default_rviz2_path],
+                arguments=["-d", LaunchConfiguration("rvizconfig")],
             ),
         ]
     )


### PR DESCRIPTION
Currently the `rvizconfig` can be provided like this:
`ros2 launch spot_description description.launch.py arm:=True rvizconfig:=spot_basic_rviz.rviz`

but it's getting ignored, because it takes always the default value as an argument.
This is the fix for this issue.