### PR TITLE
Bugfix: Imu sensor

### DIFF
--- a/spot_description/urdf/spot.ros2_control.xacro
+++ b/spot_description/urdf/spot.ros2_control.xacro
@@ -112,7 +112,7 @@
             <xacro:if value="${has_arm}">
                 <xacro:arm tf_prefix="${tf_prefix}" k_q_p_list="${k_q_p_validated[12:]}" k_qd_p_list="${k_qd_p_validated[12:]}"/>
             </xacro:if>
-            <sensor name="{tf_prefix}imu_sensor" tf_prefix="${tf_prefix}">
+            <sensor name="${tf_prefix}imu_sensor">
                 <state_interface name="orientation.x"/>
                 <state_interface name="orientation.y"/>
                 <state_interface name="orientation.z"/>


### PR DESCRIPTION
Fixes the TF arg for the IMU sensor

# Testing 
- [x] Tested output is well formed with and without tf_prefix arg set 