### PR TITLE
Gaddison/sw 2455 add twist state interfaces

### DIFF
--- a/spot_description/urdf/spot.ros2_control.xacro
+++ b/spot_description/urdf/spot.ros2_control.xacro
@@ -159,6 +159,14 @@
                 <state_interface name="foot_state.back.right"/>
             </sensor>
             <xacro:pose_sensor sensor_name="${tf_prefix}odom_t_body"/>
+            <sensor name="${tf_prefix}odom_twist_body">
+                <state_interface name="linear.x"/>
+                <state_interface name="linear.y"/>
+                <state_interface name="linear.z">
+                <state_interface name="angular.x"/>
+                <state_interface name="angular.y"/>
+                <state_interface name="angular.z"/>
+            </sensor>
             <xacro:pose_sensor sensor_name="${tf_prefix}vision_t_body"/>
         </ros2_control>
     </xacro:macro>

--- a/spot_description/urdf/spot.ros2_control.xacro
+++ b/spot_description/urdf/spot.ros2_control.xacro
@@ -162,7 +162,7 @@
             <sensor name="${tf_prefix}odom_twist_body">
                 <state_interface name="linear.x"/>
                 <state_interface name="linear.y"/>
-                <state_interface name="linear.z">
+								<state_interface name="linear.z"/>
                 <state_interface name="angular.x"/>
                 <state_interface name="angular.y"/>
                 <state_interface name="angular.z"/>

--- a/spot_description/urdf/spot.ros2_control.xacro
+++ b/spot_description/urdf/spot.ros2_control.xacro
@@ -162,7 +162,7 @@
             <sensor name="${tf_prefix}odom_twist_body">
                 <state_interface name="linear.x"/>
                 <state_interface name="linear.y"/>
-								<state_interface name="linear.z"/>
+                <state_interface name="linear.z"/>
                 <state_interface name="angular.x"/>
                 <state_interface name="angular.y"/>
                 <state_interface name="angular.z"/>


### PR DESCRIPTION
Exposing the odom_to_body twist state information provided by BD's spot-sdk.

This was built w/ corresponding changes to [spot_hardware_interface](https://github.com/bdaiinstitute/spot_ros2/pull/668).