### PR TITLE
Add flag to enable/disable rviz

### DIFF
--- a/spot_description/launch/description.launch.py
+++ b/spot_description/launch/description.launch.py
@@ -25,6 +25,12 @@ def generate_launch_description() -> launch.LaunchDescription:
                 name="model", default_value=default_model_path, description="Absolute path to robot urdf file"
             ),
             DeclareLaunchArgument(
+                name="rviz",
+                default_value="True",
+                choices=["True", "true", "False", "false"],
+                description="Flag to enable rviz gui",
+            ),
+            DeclareLaunchArgument(
                 name="rvizconfig", default_value=default_rviz2_path, description="Absolute path to rviz config file"
             ),
             DeclareLaunchArgument(
@@ -91,6 +97,7 @@ def generate_launch_description() -> launch.LaunchDescription:
                 executable="rviz2",
                 name="rviz2",
                 output="screen",
+                condition=launch.conditions.IfCondition(LaunchConfiguration("rviz")),
                 arguments=["-d", LaunchConfiguration("rvizconfig")],
             ),
         ]

--- a/spot_description/launch/standalone_arm.launch.py
+++ b/spot_description/launch/standalone_arm.launch.py
@@ -19,6 +19,12 @@ def generate_launch_description() -> launch.LaunchDescription:
             launch.actions.DeclareLaunchArgument(
                 name="model", default_value=default_model_path, description="Absolute path to robot urdf file"
             ),
+            DeclareLaunchArgument(
+                name="rviz",
+                default_value="True",
+                choices=["True", "true", "False", "false"],
+                description="Flag to enable rviz gui",
+            ),
             launch.actions.DeclareLaunchArgument(
                 name="rvizconfig", default_value=default_rviz2_path, description="Absolute path to rviz config file"
             ),
@@ -44,6 +50,7 @@ def generate_launch_description() -> launch.LaunchDescription:
                 executable="rviz2",
                 name="rviz2",
                 output="screen",
+                condition=launch.conditions.IfCondition(LaunchConfiguration("gui")),
                 arguments=["-d" + default_rviz2_path],
             ),
         ]


### PR DESCRIPTION
Sometimes it's is required to only have the state publisher, without the RVIZ gui.

This pull request adds a flag to both of the launch files.
Compatible with all current uses, because default set to "True"