### PR TITLE
Change to new RAI Institute copyright

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2023-2024 The AI Institute
+Copyright (c) 2023-2024 Robotics and AI Institute LLC dba RAI Institute.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+<!-- Copyright (c) 2025 Robotics and AI Institute LLC dba RAI Institute. All rights reserved. -->
+
 # spot_description
 
 This ROS 2 package contains the URDF files for Spot. There are two Spot models, referred to as `spot` and `spot_simple`, which primarily differ in the number of links in the base frame. There is also a `standalone_arm` model to view the Spot Arm independently. 

--- a/spot_description/CMakeLists.txt
+++ b/spot_description/CMakeLists.txt
@@ -1,3 +1,5 @@
+# Copyright (c) 2025 Robotics and AI Institute LLC dba RAI Institute. All rights reserved.
+
 cmake_minimum_required(VERSION 3.5)
 project(spot_description)
 

--- a/spot_description/__init__.py
+++ b/spot_description/__init__.py
@@ -1,0 +1,4 @@
+# Copyright (c) 2025 Robotics and AI Institute LLC dba RAI Institute. All rights reserved.
+
+
+

--- a/spot_description/launch/description.launch.py
+++ b/spot_description/launch/description.launch.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Boston Dynamics AI Institute LLC. All rights reserved.
+# Copyright (c) 2023-2024 Robotics and AI Institute LLC dba RAI Institute. All rights reserved.
 
 import os
 

--- a/spot_description/launch/standalone_arm.launch.py
+++ b/spot_description/launch/standalone_arm.launch.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Boston Dynamics AI Institute LLC. All rights reserved.
+# Copyright (c) 2023-2024 Robotics and AI Institute LLC dba RAI Institute. All rights reserved.
 
 import os
 

--- a/spot_description/package.xml
+++ b/spot_description/package.xml
@@ -1,5 +1,8 @@
 <?xml version="1.0"?>
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+
+<!-- Copyright (c) 2025 Robotics and AI Institute LLC dba RAI Institute. All rights reserved. -->
+
 <package format="3">
   <name>spot_description</name>
   <version>0.0.0</version>

--- a/spot_description/urdf/README.md
+++ b/spot_description/urdf/README.md
@@ -1,3 +1,5 @@
+<!-- Copyright (c) 2025 Robotics and AI Institute LLC dba RAI Institute. All rights reserved. -->
+
 # Spot URDF Files
 
 | name                      | purpose                                                                                |

--- a/spot_description/urdf/accessories.urdf.xacro
+++ b/spot_description/urdf/accessories.urdf.xacro
@@ -1,4 +1,7 @@
 <?xml version="1.0"?>
+
+<!-- Copyright (c) 2025 Robotics and AI Institute LLC dba RAI Institute. All rights reserved. -->
+
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro">
 
   <xacro:if value="$(optenv SPOT_PACK 0)">

--- a/spot_description/urdf/empty.urdf
+++ b/spot_description/urdf/empty.urdf
@@ -1,3 +1,5 @@
+<!-- Copyright (c) 2025 Robotics and AI Institute LLC dba RAI Institute. All rights reserved. -->
+
 <robot>
   <!-- This file is a placeholder which is included by default from
        spot.urdf.xacro. If a robot is being customized and requires

--- a/spot_description/urdf/spot.ros2_control.xacro
+++ b/spot_description/urdf/spot.ros2_control.xacro
@@ -1,4 +1,7 @@
 <?xml version="1.0"?>
+
+<!-- Copyright (c) 2025 Robotics and AI Institute LLC dba RAI Institute. All rights reserved. -->
+
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro">
 
     <xacro:macro name="ros2_control_joint"

--- a/spot_description/urdf/spot.urdf.xacro
+++ b/spot_description/urdf/spot.urdf.xacro
@@ -1,4 +1,7 @@
 <?xml version="1.0" ?>
+
+<!-- Copyright (c) 2025 Robotics and AI Institute LLC dba RAI Institute. All rights reserved. -->
+
 <robot name="spot" xmlns:xacro="http://www.ros.org/wiki/xacro">
 
   <!-- Macro for loading Spot -->

--- a/spot_description/urdf/spot_arm_macro.urdf
+++ b/spot_description/urdf/spot_arm_macro.urdf
@@ -1,4 +1,7 @@
 <?xml version="1.0"?>
+
+<!-- Copyright (c) 2025 Robotics and AI Institute LLC dba RAI Institute. All rights reserved. -->
+
 <robot name="spot_arm" xmlns:xacro="http://www.ros.org/wiki/xacro">
   <xacro:macro name="load_arm" params="
     tf_prefix

--- a/spot_description/urdf/spot_feet_macro.urdf
+++ b/spot_description/urdf/spot_feet_macro.urdf
@@ -1,5 +1,8 @@
 <?xml version="1.0"?>
 
+<!-- Copyright (c) 2025 Robotics and AI Institute LLC dba RAI Institute. All rights reserved. -->
+
+
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro">
 
   <xacro:macro name="load_feet" params="tf_prefix">

--- a/spot_description/urdf/spot_gripper_macro.urdf
+++ b/spot_description/urdf/spot_gripper_macro.urdf
@@ -1,4 +1,7 @@
 <?xml version="1.0"?>
+
+<!-- Copyright (c) 2025 Robotics and AI Institute LLC dba RAI Institute. All rights reserved. -->
+
 <robot name="spot_gripper" xmlns:xacro="http://www.ros.org/wiki/xacro">
   <xacro:macro name="load_gripper" params="
 		tf_prefix

--- a/spot_description/urdf/spot_macro.xacro
+++ b/spot_description/urdf/spot_macro.xacro
@@ -1,5 +1,8 @@
 <?xml version="1.0"?>
 
+<!-- Copyright (c) 2025 Robotics and AI Institute LLC dba RAI Institute. All rights reserved. -->
+
+
 <robot name="spot" xmlns:xacro="http://www.ros.org/wiki/xacro">
     <xacro:macro name="load_spot" params="
     arm:=false

--- a/spot_description/urdf/spot_simple.urdf.xacro
+++ b/spot_description/urdf/spot_simple.urdf.xacro
@@ -1,4 +1,7 @@
 <?xml version="1.0" ?>
+
+<!-- Copyright (c) 2025 Robotics and AI Institute LLC dba RAI Institute. All rights reserved. -->
+
 <robot name="spot" xmlns:xacro="http://www.ros.org/wiki/xacro">
   <link name="body">
     <visual>

--- a/spot_description/urdf/standalone_arm.urdf.xacro
+++ b/spot_description/urdf/standalone_arm.urdf.xacro
@@ -1,4 +1,7 @@
 <?xml version="1.0"?>
+
+<!-- Copyright (c) 2025 Robotics and AI Institute LLC dba RAI Institute. All rights reserved. -->
+
 <robot name="standalone_arm" xmlns:xacro="http://www.ros.org/wiki/xacro">
 
   <xacro:include filename="$(find spot_description)/urdf/spot_arm_macro.urdf" />

--- a/spot_description/urdf/standalone_gripper.urdf.xacro
+++ b/spot_description/urdf/standalone_gripper.urdf.xacro
@@ -1,4 +1,7 @@
 <?xml version="1.0"?>
+
+<!-- Copyright (c) 2025 Robotics and AI Institute LLC dba RAI Institute. All rights reserved. -->
+
 <robot name="standalone_gripper" xmlns:xacro="http://www.ros.org/wiki/xacro">
 
   <xacro:include filename="$(find spot_description)/urdf/spot_gripper_macro.urdf" />


### PR DESCRIPTION
Automated update to fix copyright headers with new organization name.

"Boston Dynamics AI Institute LLC" has been changed to "Robotics and AI Institute LLC" or "RAI Institute" for short.

Note that the date-stamps in the copyright headers have been preserved. Only files with existing copyrights have been modified.

This PR was created automatically.